### PR TITLE
Changed file to UTF-8

### DIFF
--- a/Xlib/protocol/display.py
+++ b/Xlib/protocol/display.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: utf-8 -*-
 #
 # Xlib.protocol.display -- core display communication
 #
@@ -761,7 +761,7 @@ class Display:
 
         # Decrement it by one, so that we don't remove the request
         # that generated these events, if there is such a one.
-        # Bug reported by Ilpo Nyyssönen
+        # Bug reported by Ilpo NyyssÃ¶nen
         self.get_waiting_request((e.sequence_number - 1) % 65536)
 
         # print 'recv Event:', e


### PR DESCRIPTION
Had an issue where a non-valid UTF-8 char broke pyinstaller. This file was the only non-UTF8 file in the repo (checked with `find . -type f | xargs -I {} bash -c "iconv -f utf-8 -t utf-16 {} &>/dev/null || echo {}"`).

PyInstaller works properly now.